### PR TITLE
fix: The displayName and detail are allowed to be modified on the product page

### DIFF
--- a/object/payment.go
+++ b/object/payment.go
@@ -54,7 +54,7 @@ type Payment struct {
 	// Order Info
 	OutOrderId string          `xorm:"varchar(100)" json:"outOrderId"`
 	PayUrl     string          `xorm:"varchar(2000)" json:"payUrl"`
-	SuccessUrl string          `xorm:"varchar(2000)" json:"successUrl""` // `successUrl` is redirected from `payUrl` after pay success
+	SuccessUrl string          `xorm:"varchar(2000)" json:"successUrl"` // `successUrl` is redirected from `payUrl` after pay success
 	State      pp.PaymentState `xorm:"varchar(100)" json:"state"`
 	Message    string          `xorm:"varchar(2000)" json:"message"`
 }

--- a/object/product.go
+++ b/object/product.go
@@ -298,8 +298,6 @@ func CreateProductForPlan(plan *Plan) *Product {
 
 func UpdateProductForPlan(plan *Plan, product *Product) {
 	product.Owner = plan.Owner
-	product.DisplayName = fmt.Sprintf("Product for Plan %v/%v/%v", plan.Name, plan.DisplayName, plan.Period)
-	product.Detail = fmt.Sprintf("This product was auto created for plan %v(%v), subscription period is %v", plan.Name, plan.DisplayName, plan.Period)
 	product.Price = plan.Price
 	product.Currency = plan.Currency
 	product.Providers = plan.PaymentProviders

--- a/routers/static_filter.go
+++ b/routers/static_filter.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
@@ -83,8 +84,14 @@ func fastAutoSignin(ctx *context.Context) (string, error) {
 		return "", fmt.Errorf(code.Message)
 	}
 
-	res := fmt.Sprintf("%s?code=%s&state=%s", redirectUri, code.Code, state)
-	return res, nil
+	// If redirectUri already has parameters, and if so, concatenate the code and state parameters with &
+	redirectUrl, _ := url.Parse(redirectUri)
+	urlParams, _ := url.ParseQuery(redirectUrl.RawQuery)
+	if urlParams != nil && len(urlParams) > 0 {
+		return fmt.Sprintf("%s&code=%s&state=%s", redirectUri, code.Code, state), nil
+	} else {
+		return fmt.Sprintf("%s?code=%s&state=%s", redirectUri, code.Code, state), nil
+	}
 }
 
 func StaticFilter(ctx *context.Context) {


### PR DESCRIPTION
The displayName and detail are allowed to be modified on the product page, so do not update the product's own displayName and detail when updating the plan.